### PR TITLE
Skip checking for unavailable files

### DIFF
--- a/MapMaker/MapMaker/Classes/Core.cs
+++ b/MapMaker/MapMaker/Classes/Core.cs
@@ -22,6 +22,7 @@ namespace MapMaker
         WebClient wc = new WebClient();
 
         public List<String> RequiredFiles = new List<string>();
+        UnavailableFilesList UnAvailableFiles = new UnavailableFilesList();
         List<String> ziplist = new List<string>();
 
         public String downloadstatus = "";
@@ -463,6 +464,7 @@ namespace MapMaker
             double height_in_metres = settings.PixelWidthInMetres * settings.ImageHeight;
             int LatHeight = (int)(height_in_metres / 111320.0) + 1;
 
+            UnAvailableFiles.SetDirectory(SRTMdirectory);
 
             for (int i = 0; i < LatHeight; i++)
             {
@@ -479,11 +481,10 @@ namespace MapMaker
             {
                 String fn = System.IO.Path.Combine(SRTMdirectory, RequiredFiles[i]);
                 fn += ".hgt";
-                if (File.Exists(fn))
+                if (UnAvailableFiles.Contains(RequiredFiles[i]) || File.Exists(fn))
                 {
                     RequiredFiles.RemoveAt(i);
                     UpdateMainDisplay(1);
-
                 }
             }
 
@@ -566,32 +567,31 @@ namespace MapMaker
                                         if (DoesFileExist(url))
                                         {
                                             DownloadFile(url, file);
-
                                         }
                                         else
                                         {
                                             missing = true;
-
                                         }
                                     }
                                 }
                             }
                         }
                     }
-                }
-                if (missing)
-                {
 
-                }
-                else
-                {
-                    lock (parent.RequiredFiles)
-                    {
-                        parent.RequiredFiles.RemoveAt(i);
-                        parent.UpdateMainDisplay(1);
-                    }
                     Thread.Sleep(50);
                 }
+
+                if (missing)
+                {
+                    parent.UnAvailableFiles.Add(parent.RequiredFiles[i]);
+                }
+
+                lock (parent.RequiredFiles)
+                {
+                    parent.RequiredFiles.RemoveAt(i);
+                }
+
+                parent.UpdateMainDisplay(1);
                 i--;
             }
             parent.download_task = "Extracting files";

--- a/MapMaker/MapMaker/Classes/UnavailableFilesList.cs
+++ b/MapMaker/MapMaker/Classes/UnavailableFilesList.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Diagnostics;
+
+namespace MapMaker
+{
+
+    public class UnavailableFilesList
+    {
+        private string Dir = "";
+
+        public void SetDirectory(string path)
+        {
+            Dir = System.IO.Path.Combine(path, "missing-files");
+            Directory.CreateDirectory(Dir);
+        }
+
+        public bool Contains(string name)
+        {
+            Debug.Assert(!String.IsNullOrWhiteSpace(Dir));
+            return File.Exists(System.IO.Path.Combine(Dir, name));
+        }
+
+        public void Add(string name)
+        {
+            Debug.Assert(!String.IsNullOrWhiteSpace(Dir));
+            File.Create(System.IO.Path.Combine(Dir, name));
+        }
+    }
+
+}

--- a/MapMaker/MapMaker/MapMaker.csproj
+++ b/MapMaker/MapMaker/MapMaker.csproj
@@ -57,6 +57,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Classes\Core.cs" />
+    <Compile Include="Classes\UnavailableFilesList.cs" />
     <Compile Include="Classes\Delta.cs" />
     <Compile Include="Classes\ProjectSettings.cs" />
     <Compile Include="Classes\SHP\SHPElement.cs" />


### PR DESCRIPTION
- skip checking whether a file exists when it is known (from a previous download attempt) to be missing on the server

- when first an encountering a missing file, an empty file with the same name is created in SRTMDIR/missing-files/